### PR TITLE
Single effect reporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ val commonSettings = Seq(
     "org.typelevel" %% "cats-effect" % "2.0.0",
     "dev.profunktor" %% "console4cats" % "0.8.0",
     "com.lihaoyi" %% "sourcecode" % "0.1.7",
-    "com.lihaoyi" %% "pprint" % "0.5.5", //todo temporary
     "com.softwaremill.diffx" %% "diffx-core" % "0.3.7"
   ) ++ compilerPlugins
 )

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ val commonSettings = Seq(
   name := "flawless",
   libraryDependencies ++= List(
     "org.typelevel" %% "cats-tagless-macros" % "0.10",
-    "org.typelevel" %% "cats-mtl-core" % "0.7.0",
     "com.github.julien-truffaut" %% "monocle-macro" % "2.0.0",
     "org.typelevel" %% "cats-effect" % "2.0.0",
     "dev.profunktor" %% "console4cats" % "0.8.0",

--- a/core/src/main/scala/flawless/TestApp.scala
+++ b/core/src/main/scala/flawless/TestApp.scala
@@ -5,23 +5,16 @@ import cats.effect.IOApp
 import cats.effect.Sync
 import cats.effect.Console
 import cats.effect.SyncConsole
-import cats.data.Kleisli
-import flawless.DeepConsole.Depth
-import cats.mtl.instances.all._
 import cats.effect.IO
 
 trait TestApp { self: IOApp =>
   implicit val console: Console[IO] = Console.io
 
   implicit def defaultInterpreter[F[_]: Sync]: Interpreter[F] = {
-    type Effect[A] = Kleisli[F, Depth, A]
+    implicit val console: Console[F] = SyncConsole.stdio[F]
+    implicit val reporter: Reporter[F] = Reporter.consoleInstance[F]
 
-    implicit val console: Console[Effect] = SyncConsole.stdio[F].mapK(Kleisli.liftK)
-    implicit val deepConsole: DeepConsole[Effect] = DeepConsole.instance[Effect]
-
-    implicit val reporter: Reporter[F, Effect] = Reporter.localStateInstance[F]
-
-    Interpreter.defaultInterpreter[F, Effect]
+    Interpreter.defaultInterpreter[F]
   }
 }
 

--- a/core/src/main/scala/flawless/interpreter.scala
+++ b/core/src/main/scala/flawless/interpreter.scala
@@ -5,25 +5,20 @@ import flawless.data.Suites
 import cats.data.NonEmptyList
 import cats.implicits._
 import cats.Id
-import cats.Apply
 import flawless.data.Suites.Sequence
 import flawless.data.Suites.One
-import cats.Show
-import cats.effect.ConsoleOut
-import cats.mtl.ApplicativeLocal
-import cats.mtl.instances.all._
 import cats.Monad
 import cats.FlatMap
-import cats.data.Kleisli
-import cats.~>
 import flawless.data.Suites.RResource
 import flawless.data.Test
 import flawless.data.Assertion
 import flawless.data.TestRun
 import flawless.data.Suite
 import flawless.data.Traversal
-import flawless.DeepConsole.Depth
+import cats.tagless.finalAlg
+import cats.effect.ConsoleOut
 
+@finalAlg
 trait Interpreter[F[_]] {
 
   /**
@@ -33,7 +28,7 @@ trait Interpreter[F[_]] {
 }
 
 object Interpreter {
-  implicit def defaultInterpreter[F[_]: Monad, G[_]: Apply](implicit reporter: Reporter[F, G]): Interpreter[F] =
+  implicit def defaultInterpreter[F[_]: Monad: Reporter]: Interpreter[F] =
     new Interpreter[F] {
       private val interpretTest: Test[F] => F[Test[Id]] = { test =>
         def finish(results: NonEmptyList[Assertion]): Test[Id] = Test(test.name, TestRun.Pure(results))
@@ -47,86 +42,53 @@ object Interpreter {
       }
 
       //todo tests in a suite should have multiple methods of traversal
-      private val interpretSuite: Suite[F] => G[Suite[Id]] = suite =>
-        suite.tests.nonEmptyTraverse(reporter.reportTest(interpretTest.map(reporter.lift(_)))).map(Suite[Id](suite.name, _))
+      private val interpretSuite: Suite[F] => F[Suite[Id]] = suite =>
+        suite.tests.nonEmptyTraverse(Reporter[F].reportTest(interpretTest)).map(Suite[Id](suite.name, _))
 
-      val interpretN: Suites[F] => G[Suites[Id]] = {
+      val interpret: Suites[F] => F[Suites[Id]] = {
         case Sequence(suites, traversal) =>
           val interpreted = traversal.traverse(suites) {
             //this interpret call will make sure every spec starts with a clean depth scope - watch this space
             interpret
           }
 
-          reporter.lift(interpreted).map(Sequence(_, Traversal.identity))
-        case One(suite) => reporter.reportSuite(interpretSuite)(suite).map(One(_))
+          interpreted.map(Sequence(_, Traversal.identity))
+        case One(suite) => Reporter[F].reportSuite(interpretSuite)(suite).map(One(_))
         case RResource(suites, b) =>
           implicit val bracket = b
-          reporter.lift(suites.use(interpret))
+          suites.use(interpret)
       }
-
-      val interpret: Suites[F] => F[Suites[Id]] = interpretN.map(reporter.run(_))
     }
 }
 
-trait DeepConsole[F[_]] {
-  def putStrLn[A: Show](a: A): F[Unit]
-  def nested[A](fa: F[A]): F[A]
-}
-
-object DeepConsole {
-  def apply[F[_]](implicit F: DeepConsole[F]): DeepConsole[F] = F
-
-  final case class Depth(value: Int) extends AnyVal {
-    def deeper: Depth = Depth(value + 1)
-  }
-
-  object Depth {
-    type Local[F[_]] = ApplicativeLocal[F, Depth]
-    def local[F[_]](implicit F: Local[F]): Local[F] = F
-  }
-
-  def instance[F[_]: ConsoleOut: Depth.Local: FlatMap]: DeepConsole[F] = new DeepConsole[F] {
-    private val spaces = Depth.local[F].ask.map(" " * 2 * _.value)
-
-    def putStrLn[A: Show](a: A): F[Unit] = spaces.flatMap(spacesString => ConsoleOut[F].putStrLn(spacesString + a))
-
-    def nested[A](fa: F[A]): F[A] = Depth.local[F].local(_.deeper)(fa)
-  }
-}
-
-trait Reporter[F[_], G[_]] {
-  //lift the execution effect to the reporting effect
-  def lift: F ~> G
-  //apply the reporting effect and unlift to execution effect
-  def run: G ~> F
-
-  def reportTest: (Test[F] => G[Test[Id]]) => Test[F] => G[Test[Id]]
-  def reportSuite: (Suite[F] => G[Suite[Id]]) => Suite[F] => G[Suite[Id]]
+@finalAlg
+trait Reporter[F[_]] {
+  def reportTest: (Test[F] => F[Test[Id]]) => Test[F] => F[Test[Id]]
+  def reportSuite: (Suite[F] => F[Suite[Id]]) => Suite[F] => F[Suite[Id]]
 }
 
 object Reporter {
-  def apply[F[_], G[_]](implicit F: Reporter[F, G]): Reporter[F, G] = F
 
-  def consoleInstance[F[_], G[_]: FlatMap, A](_lift: F ~> G, _unlift: G ~> F)(implicit DC: DeepConsole[G]): Reporter[F, G] =
-    new Reporter[F, G] {
-      val lift: F ~> G = _lift
-      val run: G ~> F = _unlift
+  def consoleInstance[F[_]: FlatMap: ConsoleOut]: Reporter[F] =
+    new Reporter[F] {
 
-      val reportTest: (Test[F] => G[Test[Id]]) => Test[F] => G[Test[Id]] = f =>
+      private def putStrWithDepth(depth: Int): String => F[Unit] = s => ConsoleOut[F].putStrLn(" " * depth * 2 + s)
+
+      private val putSuite = ConsoleOut[F].putStrLn(_: String)
+      private val putTest = putStrWithDepth(1)
+
+      val reportTest: (Test[F] => F[Test[Id]]) => Test[F] => F[Test[Id]] = run =>
         test =>
           //this is going to need access to a summarizer of tests,
           //so that it can display the amount of assertions that succeeded, failed, etc., with colors
-          DC.putStrLn("Starting test: " + test.name) *> f(test).flatTap { result =>
-            DC.putStrLn("Finished test: " + test.name + s", result: ${result.result}")
+          putTest("Starting test: " + test.name) *> run(test).flatTap { result =>
+            putTest("Finished test: " + test.name + s", result: ${result.result}")
           }
 
-      val reportSuite: (Suite[F] => G[Suite[Id]]) => Suite[F] => G[Suite[Id]] = f =>
+      val reportSuite: (Suite[F] => F[Suite[Id]]) => Suite[F] => F[Suite[Id]] = run =>
         suite =>
-          DC.putStrLn("Starting suite: " + suite.name) *> DC.nested(f(suite)).flatTap { result =>
-            DC.putStrLn("Finished suite: " + suite.name + s", result: ${result.tests}")
+          putSuite("Starting suite: " + suite.name) *> run(suite).flatTap { result =>
+            putSuite("Finished suite: " + suite.name + s", result: ${result.tests}")
           }
     }
-
-  def localStateInstance[F[_]: FlatMap](implicit DC: DeepConsole[Kleisli[F, Depth, *]]): Reporter[F, Kleisli[F, Depth, *]] =
-    consoleInstance(Kleisli.liftK, λ[Kleisli[F, Depth, *] ~> F](_.run(Depth(0))))
 }

--- a/tests/src/main/scala/flawless/tests/FlawlessTests.scala
+++ b/tests/src/main/scala/flawless/tests/FlawlessTests.scala
@@ -5,11 +5,15 @@ import cats.effect.IO
 import cats.effect.IOApp
 import flawless._
 import flawless.TestApp
+import flawless.data.Suites
 
 //test runner for the whole module
 object FlawlessTests extends IOApp with TestApp {
 
   def run(args: List[String]): IO[ExitCode] = runTests[IO](args) {
-    GetStatsTest.runSuite.toSuites
+    Suites.sequential(
+      GetStatsTest.runSuite.toSuites,
+      ReporterTest.runSuite.toSuites
+    )
   }
 }

--- a/tests/src/main/scala/flawless/tests/ReporterTest.scala
+++ b/tests/src/main/scala/flawless/tests/ReporterTest.scala
@@ -1,0 +1,62 @@
+package flawless.tests
+import flawless.SuiteClass
+
+import flawless.data.Suite
+import flawless.dsl._
+import cats.implicits._
+import flawless.Reporter
+import flawless.DeepConsole
+import flawless.DeepConsole.Depth
+import cats.effect.ConsoleOut
+import cats.data.Writer
+import cats.data.ReaderT
+import cats.data.Chain
+import cats.mtl.instances.all._
+import flawless.Interpreter
+import cats.Show
+
+object ReporterTest extends SuiteClass[NoEffect] {
+  type WC[A] = Writer[Chain[String], A]
+
+  type RWC[A] = ReaderT[Writer[Chain[String], ?], Depth, A]
+
+  implicit val cout: ConsoleOut[RWC] = new ConsoleOut[RWC] {
+    def putStr[A: Show](a: A): RWC[Unit] = ReaderT.liftF(Writer.tell(Chain(a.show)))
+    def putStrLn[A: Show](a: A): RWC[Unit] = ReaderT.liftF(Writer.tell(Chain(show"$a\n")))
+  }
+
+  implicit val dc: DeepConsole[RWC] =
+    DeepConsole.instance[RWC]
+
+  implicit val reporter: Reporter[WC, RWC] = Reporter.localStateInstance[WC]
+
+  val interpreter: Interpreter[WC] = Interpreter.defaultInterpreter[WC, RWC]
+
+  val runSuite: Suite[NoEffect] = suite("ReporterTest") {
+    tests(
+      pureTest("suite with two tests") {
+
+        val testedSuite = suite("suite 1") {
+          tests(
+            test[WC]("test 1")(ensureEqual(1, 1).pure[WC]),
+            test[WC]("test 2")(ensureEqual(1, 1).pure[WC])
+          )
+        }.toSuites
+
+        val test1Result = "Pure(NonEmptyList(Successful))"
+        val test2Result = "Pure(NonEmptyList(Successful))"
+        val suiteResult = show"NonEmptyList(Test(test 1,$test1Result), Test(test 2,$test2Result))"
+
+        val expectedOut =
+          show"""Starting suite: suite 1
+                |  Starting test: test 1
+                |  Finished test: test 1, result: $test1Result
+                |  Starting test: test 2
+                |  Finished test: test 2, result: $test2Result
+                |Finished suite: suite 1, result: $suiteResult""".stripMargin.linesIterator.toList.map(_ + "\n")
+
+        ensureEqual(interpreter.interpret(testedSuite).written.toList, expectedOut)
+      }
+    )
+  }
+}


### PR DESCRIPTION
This PR removes the second type parameter of the Reporter trait, effectively getting rid of DeepConsole and cats-mtl.

This should simplify the reporting a bit, and if there's ever a need to keep track of the depth of tests, it might be possible to implement without polluting everything with another effect type.