### PR TITLE
Fix incorrect positioning of suites replacing another one

### DIFF
--- a/core/src/main/scala/flawless/eval/interpreter.scala
+++ b/core/src/main/scala/flawless/eval/interpreter.scala
@@ -19,6 +19,10 @@ import cats.effect.concurrent.Ref
 import cats.FlatMap
 import cats.MonadError
 import scala.util.control.NonFatal
+import monocle.macros.Lenses
+import scala.annotation.tailrec
+import cats.data.Chain
+import cats.data.Chain.==:
 
 @finalAlg
 trait Interpreter[F[_]] {
@@ -97,7 +101,7 @@ object Interpreter {
           case r: RResource[f] => r.resuite.use(interpretOne(parentId))(r.bracket)
         }
 
-        s => reporter.ident.flatMap(interpretOne(_)(s))
+        interpretOne(reporter.root)
       }
     }
 }
@@ -105,6 +109,7 @@ object Interpreter {
 @finalAlg
 trait Reporter[F[_]] {
   type Identifier
+  def root: Identifier
   def ident: F[Identifier]
   def publish(event: Reporter.Event[Identifier]): F[Unit]
 }
@@ -128,12 +133,13 @@ object Reporter {
     implicit def eq[Identifier]: Eq[Event[Identifier]] = Eq.fromUniversalEquals
   }
 
-  final case class SuiteHistory(cells: List[SuiteHistory.Cell]) {
+  @Lenses
+  final case class SuiteHistory(cells: Chain[SuiteHistory.Cell]) {
 
     //reference implementation, will be overridden for more performance (and possibly no fs2 dependency)
     def stringify: String = {
       fs2.Stream.emit(Console.RESET) ++
-        fs2.Stream.emits(cells).groupAdjacentBy(_.status).map(_.map(_.size)).map {
+        cells.foldMap(fs2.Stream.emit(_)).groupAdjacentBy(_.status).map(_.map(_.size)).map {
           case (status, cellCount) => status.color ++ status.stringify.combineN(cellCount)
         } ++
         fs2.Stream.emit(Console.RESET)
@@ -169,18 +175,36 @@ object Reporter {
       implicit val eq: Eq[Status] = Eq.fromUniversalEquals
     }
 
-    val initial: SuiteHistory = SuiteHistory(Nil)
+    def initial(rootId: Unique): SuiteHistory = SuiteHistory(Chain.one(Cell(rootId, Status.Pending)))
 
     type MState[F[_]] = MonadState[F, SuiteHistory]
     def MState[F[_]](implicit F: MState[F]): MState[F] = F
 
+    /* private */
+    def flatReplaceFirst[A](f: PartialFunction[A, Chain[A]]): Chain[A] => Chain[A] = {
+
+      @tailrec
+      def go(list: Chain[A], memory: Chain[A]): Chain[A] = list match {
+        case Chain.nil => memory
+        case head ==: tail =>
+          f.lift(head) match {
+            case Some(elems) => memory ++ elems ++ tail
+            case None        => go(tail, memory append head)
+          }
+      }
+
+      go(_, Chain.nil)
+    }
+
     def replace[F[_]: MState](toRemove: Unique, cells: NonEmptyList[Cell]): F[Unit] =
       MState[F].modify(
-        c =>
-          c.copy(c.cells.filter {
-            case Cell(`toRemove`, Status.Pending) => false
-            case _                                => true
-          } ++ cells.toList)
+        SuiteHistory
+          .cells
+          .modify(
+            flatReplaceFirst {
+              case Cell(`toRemove`, Status.Pending) => Chain.fromSeq(cells.toList)
+            }
+          )
       )
 
     def markRunning[F[_]: MState](id: Unique): F[Unit] = updateStatus[F] {
@@ -208,8 +232,8 @@ object Reporter {
     def show[F[_]: MState: FlatMap: ConsoleOut]: F[Unit] =
       MState[F].get.flatMap { result =>
         val clear = "\u001b[2J\u001b[H"
-
-        if (result.cells.map(_.status).contains_(Status.Pending))
+        //no `map` for laziness
+        if (result.cells.exists(_.status === Status.Pending))
           ConsoleOut[F].putStrLn(clear ++ result.stringify)
         else ConsoleOut[F].putStrLn(clear ++ "Finished")
       }
@@ -218,6 +242,9 @@ object Reporter {
   def consoleInstance[F[_]: Sync: ConsoleOut]: F[Reporter[F]] = Ref[F].of(0).map { identifiers =>
     new Reporter[F] {
       type Identifier = Int
+
+      val root: Int = 0
+
       val ident: F[Identifier] = identifiers.modify(a => (a + 1, a))
 
       private def putStrWithDepth(depth: Int): String => F[Unit] = s => ConsoleOut[F].putStrLn(" " * depth * 2 + s)
@@ -238,24 +265,30 @@ object Reporter {
 
   import com.olegpy.meow.effects._
 
-  def visual[F[_]: Sync: ConsoleOut]: F[Reporter[F]] =
-    Ref[F].of(SuiteHistory.initial).map(_.stateInstance).map { implicit S =>
-      new Reporter[F] {
-        type Identifier = Unique
-        val ident: F[Unique] = Sync[F].delay(new Unique)
+  def visual[F[_]: Sync: ConsoleOut]: F[Reporter[F]] = {
+    val newId = Sync[F].delay(new Unique)
 
-        def publish(event: Event[Identifier]): F[Unit] = {
-          event match {
-            case Event.SuiteStarted(_, id)        => SuiteHistory.markRunning(id)
-            case Event.SuiteFinished(_, id, succ) => SuiteHistory.markFinished(id, succ)
-            case Event.ReplaceSuiteWith(toRemove, toReplace) =>
-              val newCells: NonEmptyList[SuiteHistory.Cell] =
-                toReplace.tupleRight(SuiteHistory.Status.Pending).map(SuiteHistory.Cell.tupled)
-              SuiteHistory.replace(toRemove, newCells)
+    newId.flatMap { rootIdent =>
+      Ref[F].of(SuiteHistory.initial(rootIdent)).map(_.stateInstance).map { implicit S =>
+        new Reporter[F] {
+          type Identifier = Unique
+          val root: Unique = rootIdent
+          val ident: F[Unique] = newId
 
-            case _ => Applicative[F].unit
-          }
-        } *> SuiteHistory.show
+          def publish(event: Event[Identifier]): F[Unit] = {
+            event match {
+              case Event.SuiteStarted(_, id)        => SuiteHistory.markRunning(id)
+              case Event.SuiteFinished(_, id, succ) => SuiteHistory.markFinished(id, succ)
+              case Event.ReplaceSuiteWith(toRemove, toReplace) =>
+                val newCells: NonEmptyList[SuiteHistory.Cell] =
+                  toReplace.map(SuiteHistory.Cell(_, SuiteHistory.Status.Pending))
+                SuiteHistory.replace(toRemove, newCells)
+
+              case _ => Applicative[F].unit
+            }
+          } *> SuiteHistory.show
+        }
       }
     }
+  }
 }

--- a/tests/src/main/scala/flawlessly/HistoryStringifyTests.scala
+++ b/tests/src/main/scala/flawlessly/HistoryStringifyTests.scala
@@ -5,6 +5,7 @@ import flawless._
 import flawless.syntax._
 import cats.implicits._
 import flawless.eval.unique.Unique
+import cats.data.Chain
 
 object HistoryStringifyTests extends SuiteClass[NoEffect] {
   import flawless.eval.Reporter.SuiteHistory
@@ -22,7 +23,7 @@ object HistoryStringifyTests extends SuiteClass[NoEffect] {
       },
       pureTest("stringify on a history") {
         val history = SuiteHistory(
-          List(
+          Chain(
             4 -> Status.Succeeded,
             1 -> Status.Failed,
             1 -> Status.Succeeded,
@@ -32,7 +33,7 @@ object HistoryStringifyTests extends SuiteClass[NoEffect] {
             2 -> Status.Pending,
             1 -> Status.Succeeded,
             2 -> Status.Pending
-          ).flatMap { case (n, status) => List.fill(n)(status) }.map(Cell(u, _))
+          ).flatMap { case (n, status) => Chain.fromSeq(List.fill(n)(status)) }.map(Cell(u, _))
         )
 
         def green(s: String) = Console.GREEN ++ s

--- a/tests/src/main/scala/flawlessly/InterpreterReportingTest.scala
+++ b/tests/src/main/scala/flawlessly/InterpreterReportingTest.scala
@@ -39,8 +39,9 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
       S[_]: Alternative
     ]: Reporter.Aux[M, Int] = new Reporter[M] {
       type Identifier = Int
+      val root: Int = 0
 
-      val ident: M[Identifier] = MonadState[M, Int].get <* MonadState[M, Int].modify(_ + 1)
+      val ident: M[Identifier] = MonadState[M, Int].modify(_ + 1) *> MonadState[M, Int].get
 
       def publish(event: Reporter.Event[Identifier]): M[Unit] =
         FunctorTell[M, S[Reporter.Event[Int]]].tell(event.pure[S])

--- a/tests/src/main/scala/flawlessly/InterpreterReportingTest.scala
+++ b/tests/src/main/scala/flawlessly/InterpreterReportingTest.scala
@@ -15,7 +15,6 @@ import cats.effect.Sync
 import cats.Foldable
 import flawless.data.Assertion
 import cats.data.NonEmptyList
-import com.softwaremill.diffx.cats._
 import cats.Parallel
 import cats.mtl.MonadState
 import cats.mtl.FunctorTell
@@ -26,7 +25,15 @@ import cats.data.`package`.ReaderWriterStateT
 
 //Sync, because Bracket for WriterT isn't explicitly written
 final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
-  type WC[A] = ReaderWriterStateT[F, Unit, Chain[Reporter.Event[Int]], Int, A]
+  sealed trait LogEvent extends Product with Serializable
+
+  object LogEvent {
+    case class ReplaceWith(parent: Int, childCount: Int) extends LogEvent
+    case class Report(event: Reporter.Event[Int]) extends LogEvent
+    implicit val show: Show[LogEvent] = Show.fromToString
+  }
+
+  type WC[A] = ReaderWriterStateT[F, Unit, Chain[LogEvent], Int, A]
 
   //The instance shall not be used for parallelism! It's pretty much just a marker
   implicit val parallelState: Parallel[WC] = Parallel.identity
@@ -35,17 +42,25 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
 
   val reporter: Reporter.Aux[WC, Int] = {
     def make[
-      M[_]: MonadState[*[_], Int]: Monad: FunctorTell[*[_], S[Reporter.Event[Int]]],
+      M[_]: MonadState[*[_], Int]: Monad: FunctorTell[*[_], S[LogEvent]],
       S[_]: Alternative
-    ]: Reporter.Aux[M, Int] = new Reporter[M] {
-      type Identifier = Int
-      val root: Int = 0
+    ]: Reporter.Aux[M, Int] =
+      new Reporter[M] {
+        type Identifier = Int
+        val root: Int = 0
 
-      val ident: M[Identifier] = MonadState[M, Int].modify(_ + 1) *> MonadState[M, Int].get
+        private val logger = FunctorTell[M, S[LogEvent]]
 
-      def publish(event: Reporter.Event[Identifier]): M[Unit] =
-        FunctorTell[M, S[Reporter.Event[Int]]].tell(event.pure[S])
-    }
+        private val ident: M[Identifier] = MonadState[M, Int].modify(_ + 1) *> MonadState[M, Int].get
+
+        def createChildren(parent: Int, count: Int): M[NonEmptyList[Int]] =
+          logger.tell((LogEvent.ReplaceWith(parent, count): LogEvent).pure[S]) *> ident
+            .replicateA(count)
+            .map(NonEmptyList.fromListUnsafe)
+
+        def publish(event: Reporter.Event[Identifier]): M[Unit] =
+          logger.tell((LogEvent.Report(event): LogEvent).pure[S])
+      }
 
     make[WC, Chain]
   }
@@ -63,18 +78,19 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
 
   import Reporter.Event._
 
-  def simpleEvents(id: Int): List[Reporter.Event[Int]] = List(
-    SuiteStarted("suite 1", id),
-    TestStarted("test 1"),
-    TestFinished("test 1"),
-    TestStarted("test 2"),
-    TestFinished("test 2"),
-    SuiteFinished("suite 1", id, succeeded = true)
-  )
+  def simpleEvents(id: Int): List[LogEvent] =
+    List[Reporter.Event[Int]](
+      SuiteStarted("suite 1", id),
+      TestStarted("test 1"),
+      TestFinished("test 1"),
+      TestStarted("test 2"),
+      TestFinished("test 2"),
+      SuiteFinished("suite 1", id, succeeded = true)
+    ).map(LogEvent.Report(_))
 
   def simpleResource(suite: Suite[WC]): Suite[WC] = Suite.resource(suite.pure[Resource[WC, *]])
 
-  def ensureReported[G[_]: Foldable](suite: Suite[WC])(expectedWritten: G[Reporter.Event[Int]]): F[Assertion] =
+  def ensureReported[G[_]: Foldable](suite: Suite[WC])(expectedWritten: G[LogEvent]): F[Assertion] =
     interpreter.interpret(reporter)(suite).written.runA((), 0).map(_.toList).map(ensureEqual(_, expectedWritten.toList))
 
   //todo: these would be good property tests
@@ -87,7 +103,7 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
         ensureReported {
           Suite.sequential(simpleSuite, simpleSuite)
         } {
-          List(ReplaceSuiteWith(0, NonEmptyList.of(1, 2))) ++
+          List(LogEvent.ReplaceWith(0, 2)) ++
             simpleEvents(1) ++
             simpleEvents(2)
         }
@@ -96,7 +112,7 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
         ensureReported {
           Suite.sequential(Suite.sequential(simpleSuite), simpleSuite, simpleSuite)
         } {
-          List(ReplaceSuiteWith(0, NonEmptyList.of(1, 2, 3))) ++
+          List(LogEvent.ReplaceWith(0, 3)) ++
             simpleEvents(1) ++
             simpleEvents(2) ++
             simpleEvents(3)
@@ -106,7 +122,7 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
         ensureReported {
           Suite.sequential(simpleSuite, simpleSuite, Suite.sequential(simpleSuite))
         } {
-          List(ReplaceSuiteWith(0, NonEmptyList.of(1, 2, 3))) ++
+          List(LogEvent.ReplaceWith(0, 3)) ++
             simpleEvents(1) ++
             simpleEvents(2) ++
             simpleEvents(3)
@@ -126,10 +142,10 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
             )
           )
         } {
-          List(ReplaceSuiteWith(0, NonEmptyList.of(1, 2, 3))) ++
+          List(LogEvent.ReplaceWith(0, 3)) ++
             simpleEvents(1) ++
             simpleEvents(2) ++
-            List(ReplaceSuiteWith(3, NonEmptyList.of(4, 5, 6, 7))) ++
+            List(LogEvent.ReplaceWith(3, 4)) ++
             simpleEvents(4) ++
             simpleEvents(5) ++
             simpleEvents(6) ++
@@ -140,7 +156,7 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
         ensureReported {
           Suite.sequential(Suite.sequential(simpleSuite), Suite.sequential(simpleSuite))
         } {
-          List(ReplaceSuiteWith(0, NonEmptyList.of(1, 2))) ++
+          List(LogEvent.ReplaceWith(0, 2)) ++
             simpleEvents(1) ++
             simpleEvents(2)
         }
@@ -162,10 +178,10 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
           )
         } {
           List(
-            ReplaceSuiteWith(0, NonEmptyList.of(1, 2, 3)).pure[List],
+            LogEvent.ReplaceWith(0, 3).pure[List],
             simpleEvents(1),
             simpleEvents(2),
-            ReplaceSuiteWith(3, NonEmptyList.of(4, 5)).pure[List],
+            LogEvent.ReplaceWith(3, 2).pure[List],
             simpleEvents(4),
             simpleEvents(5)
           ).flatten

--- a/tests/src/main/scala/flawlessly/InterpreterReportingTest.scala
+++ b/tests/src/main/scala/flawlessly/InterpreterReportingTest.scala
@@ -53,7 +53,7 @@ final class InterpreterReportingTest[F[_]: Sync] extends SuiteClass[F] {
 
         private val ident: M[Identifier] = MonadState[M, Int].modify(_ + 1) *> MonadState[M, Int].get
 
-        def createChildren(parent: Int, count: Int): M[NonEmptyList[Int]] =
+        def splitParent(parent: Int, count: Int): M[NonEmptyList[Int]] =
           logger.tell((LogEvent.ReplaceWith(parent, count): LogEvent).pure[S]) *> ident
             .replicateA(count)
             .map(NonEmptyList.fromListUnsafe)


### PR DESCRIPTION
Also merges the `ident` method in `Reporter` with the `ReplaceSuiteWith` event, as they should always be used together. Now only a command for creating N child suites remains, and it replaces the parent automatically.